### PR TITLE
Move trusted-registries to config file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,6 @@ jobs:
     name: "Hadolint"
     steps:
       - uses: actions/checkout@main
-      - uses: hadolint/hadolint-action@v1.7.0
+      - uses: hadolint/hadolint-action@v2.0.0
         with:
           recursive: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,3 @@ jobs:
       - uses: hadolint/hadolint-action@v1.7.0
         with:
           recursive: true
-          trusted-registries: 'docker.io'

--- a/.hadolint.yml
+++ b/.hadolint.yml
@@ -1,2 +1,5 @@
 ignored:
   - DL3041
+
+trustedRegistries:
+  - docker.io


### PR DESCRIPTION
Sets `trusted-registries` for all execution types, not just CI.