### PR TITLE
Apache Maven 3.8.6 update

### DIFF
--- a/java-maven/Dockerfile
+++ b/java-maven/Dockerfile
@@ -12,7 +12,7 @@ LABEL \
 ARG JAVA_VERSION=11
 
 RUN dnf install -y java-${JAVA_VERSION}-openjdk-devel git && \
-        MAVEN_VERSION="3.8.5" && \
+        MAVEN_VERSION="3.8.6" && \
         curl --silent -o maven.tar.gz --output-dir /tmp \
             https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
         mkdir /opt/maven && \


### PR DESCRIPTION
Update to latest Maven 3.8.6.

closes #8 