### PR TITLE
Update hadolint-action to 3.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,6 @@ jobs:
     name: "Hadolint"
     steps:
       - uses: actions/checkout@main
-      - uses: hadolint/hadolint-action@v2.1.0
+      - uses: hadolint/hadolint-action@v3.0.0
         with:
           recursive: true

--- a/java-maven/Dockerfile
+++ b/java-maven/Dockerfile
@@ -11,10 +11,10 @@ LABEL \
 
 ARG JAVA_VERSION=11
 
-RUN dnf install -y java-${JAVA_VERSION}-openjdk-devel git && \
+RUN dnf install -y java-"${JAVA_VERSION}"-openjdk-devel git && \
         MAVEN_VERSION="3.8.6" && \
         curl --silent -o maven.tar.gz --output-dir /tmp \
-            https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
+            "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" && \
         mkdir /opt/maven && \
         tar xf /tmp/maven.tar.gz -C /opt/maven --strip-components=1 && \
         rm -rf /tmp/* && \


### PR DESCRIPTION
Updates hadolint-action to it's latest release, featuring hadolint 2.12 and fixes a warning.
