### PR TITLE
Update Shellcheck to v0.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        shellcheck_version: [ '0.8.0' ]
+        shellcheck_version: [ '0.8.0', '0.9.0' ]
     name: "Build shellcheck:${{ matrix.shellcheck_version}}"
     env:
       FULL_IMAGE_NAME: "ghcr.io/${{ github.repository }}/shellcheck"

--- a/README.md
+++ b/README.md
@@ -27,4 +27,5 @@ Images are available on [GHCR](https://github.com/jhnc-oss/images/pkgs/container
 #### [shellcheck](./shellcheck/Dockerfile)
 
 - `0.8.0`
+- `0.9.0`
 

--- a/shellcheck/Dockerfile
+++ b/shellcheck/Dockerfile
@@ -8,7 +8,7 @@ LABEL \
     org.opencontainers.image.vendor="jhnc-oss" \
     org.opencontainers.image.licenses="MIT"
 
-ARG SHELLCHECK_VERSION=0.8.0
+ARG SHELLCHECK_VERSION=0.9.0
 
 RUN dnf install -y findutils xz && \
         curl -L https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz -o shellcheck.tar.xz && \


### PR DESCRIPTION
Adds an image for Shellcheck v0.9.0.

closes #21 