### PR TITLE
Remove default python and java versions

### DIFF
--- a/java-maven/Dockerfile
+++ b/java-maven/Dockerfile
@@ -9,7 +9,7 @@ LABEL \
     org.opencontainers.image.licenses="MIT"
 
 
-ARG JAVA_VERSION=11
+ARG JAVA_VERSION
 
 RUN dnf update -y && \
         dnf install -y java-"${JAVA_VERSION}"-openjdk-devel git && \

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -8,7 +8,7 @@ LABEL \
     org.opencontainers.image.vendor="jhnc-oss" \
     org.opencontainers.image.licenses="MIT"
 
-ARG PYTHON_VERSION=3.10
+ARG PYTHON_VERSION
 
 RUN dnf update -y && \
         dnf install -y python${PYTHON_VERSION} python3-pip && \


### PR DESCRIPTION
Removes the default versions from Java and Python images since there's no good default – latest isn't suitable either.