### PR TITLE
clang-format: Fail on error and support diff

### DIFF
--- a/clang-format/run-clang-format.sh
+++ b/clang-format/run-clang-format.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
 
+set -e
+
 [[ -f .clang-format-ignore ]] && IGNORE_OPTS=("--ignore-file" ".clang-format-ignore")
 fd -e c -e cpp -e cxx -e cc -e h -e hpp "${IGNORE_OPTS[@]}" -x clang-format -i
+
+if [[ "$1" == "--git-diff" ]]; then
+    /usr/bin/git diff --exit-code HEAD
+fi


### PR DESCRIPTION
Fails the run-clang-format script on error and adds support for `--git-diff` to check for formatting issues.