### PR TITLE
Deprecate Python 3.8 image

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Images are available on [GHCR](https://github.com/orgs/jhnc-oss/packages?repo_na
 - `3.11`
 - `3.10`
 - `3.9`
-- `3.8`
+- `3.8` *(Deprecated)*
 - `3.7` *(EOL)*
 
 #### [shellcheck](./shellcheck/Dockerfile)


### PR DESCRIPTION
Python 3.8 is EOL in October 2024.