### PR TITLE
Move python:3.13 out of beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Images are available on [GHCR](https://github.com/orgs/jhnc-oss/packages?repo_na
 
 #### [python](./python/Dockerfile)
 
-- `3.13` *(Beta)*
+- `3.13`
 - `3.12`
 - `3.11`
 - `3.10`


### PR DESCRIPTION
Python 3.13 is final now.