### PR TITLE
Update clang-format 19.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        clangformat_version: [ '14.0.6', '16.0.6', '17.0.6', '18.1.8', '19.1.0' ]
+        clangformat_version: [ '14.0.6', '16.0.6', '17.0.6', '18.1.8', '19.1.1' ]
     name: "Build clang-format:${{ matrix.clangformat_version}}"
     env:
       FULL_IMAGE_NAME: "ghcr.io/${{ github.repository }}/clang-format"


### PR DESCRIPTION
New version of clang-format 19 is available.